### PR TITLE
Optimize ln

### DIFF
--- a/Functions/constants.py
+++ b/Functions/constants.py
@@ -36,12 +36,3 @@ def get_e():
         e = series_sum
 
     return e
-
-def main():
-
-    print(get_e())
-    print(get_e())
-
-
-if __name__ == "__main__":
-    main()

--- a/Functions/constants.py
+++ b/Functions/constants.py
@@ -8,6 +8,7 @@ import math
 # Initial values
 pi = 0
 e = 0
+ln10 = 0
 
 # Calculate pi using the Chudnovsky algorithm
 def get_pi():
@@ -36,3 +37,16 @@ def get_e():
         e = series_sum
 
     return e
+
+def get_ln10():
+    global ln10
+
+    if ln10 == 0:
+        # if the ln(10) isn't already calculated, then calculate it for the first time and store it for the duration of runtime
+        sum = 0
+        for i in range(1000):
+            sum += (1 / (2 * i + 1)) * power_function([(10 - 1) / (10 + 1), 2 * i + 1])
+
+        ln10 = 2 * sum
+
+    return ln10

--- a/Functions/log.py
+++ b/Functions/log.py
@@ -2,6 +2,10 @@
 # Author: Steven Iacobellis
 
 from power_function import power_function
+from constants import get_ln10
+
+# Precalculated ln(10)
+ln10 = 0
 
 #Goal: Calculate the natural logarithm, log base e, of a given input x
 #Method: we use a series based on the area hyperbolic tangent function
@@ -10,16 +14,26 @@ def ln(args):
     x = 0
 
     # If the right number of arguments are passed, then continue
-    if(len(args) == 1):
+    if len(args) == 1:
         x = args[0]
     else:
         raise Exception(f"Invalid number of arguments, ln got {len(args)} but expected 1.")
 
-    #Variable used to store the calculated sum
+    a = x
+    b = 0
+
+    # we will rewrite ln(x) where x = a * 10^b, with a < 1
+    # we can then take the ln(x) = ln(a) + b * ln(10)
+    while a > 1:
+        a /= 10
+        b += 1
+
+    # Variable used to store the calculated sum
     s = 0
 
-    #Number of iterations currently hardcoded at 1000, but we can change this to an accuracy based metric by calculating the accuracy of e^s = x to a certain bound.
-    for i in range(1000):
-        s += ( 1 / (2 * i + 1) ) * power_function([(x-1) / (x+1), 2 * i + 1])
+    # Number of iterations currently hardcoded at 100, but we can change this to an accuracy based metric by
+    # calculating the accuracy of e^s = x to a certain bound.
+    for i in range(100):
+        s += (1 / (2 * i + 1)) * power_function([(a-1) / (a+1), 2 * i + 1])
 
-    return 2 * s
+    return (2 * s) + b * get_ln10()

--- a/run_tests.py
+++ b/run_tests.py
@@ -22,7 +22,7 @@ class bcolors:
     BOLD = '\033[1m'
     UNDERLINE = '\033[4m'
 
-PRECISION = 0.0000001
+PRECISION = 0.000000001
 
 
 # pi test
@@ -44,7 +44,7 @@ def pi_test():
 # ln test
 def ln_test():
     print(f'{bcolors.HEADER}ln test starting...')
-    for i in range(1, 250):
+    for i in range(1, 10000):
         calc = ln([i])
         result = math.log(i)
         error = calc - result


### PR DESCRIPTION
The taylor series chosen to calculate ln is very good at reaching high precision for input values close to 1, but rapidly loses precision as input increases.

I leveraged this by using the logarithm identity ln(x * 10^b) = ln(x) + b*ln(10) to reduce all inputs to the taylor series below zero, and have a constant precalculated ln(10). 

This ensures that precision and runtime of this function is consistent regardless of how large the input is.